### PR TITLE
fix unused webpack css

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
         <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
         <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
         <%= javascript_pack_tag 'application' %>
-        <%= stylesheet_pack_tag 'application' %>
+        <%#= stylesheet_pack_tag 'application' %>
         <%= favicon_link_tag('koken.ico') %>
     </head>
     <body>


### PR DESCRIPTION
#82 removed all CSS imports from JavaScript files but `stylesheet_pack_tag` remained, which cause the error below in production.
This PR is a workaround that comments `stylesheet_pack_tag` out.

```
ActionView::Template::Error (Webpacker can't find application.css in /workspace/public/packs/manifest.json. Possible causes:
1. You want to set webpacker.yml value of compile to true for your environment
   unless you are using the `webpack -w` or the webpack-dev-server.
2. webpack has not yet re-run to reflect updates.
3. You have misconfigured Webpacker's config/webpacker.yml file.
4. Your webpack configuration is not creating a manifest.
Your manifest contains:
{
  "application.js": "/packs/js/application-<foo>.js",
  "application.js.map": "/packs/js/application-<foo>.js.map",
  "entrypoints": {
    "application": {
      "js": [
        "/packs/js/application-<bar>.js"
      ],
      "js.map": [
        "/packs/js/application-<bar>.js.map"
      ]
    },
    "server_rendering": {
      "js": [
        "/packs/js/server_rendering-<baz>.js"
      ],
      "js.map": [
        "/packs/js/server_rendering-<baz>.js.map"
      ]
    }
  },
  "server_rendering.js": "/packs/js/server_rendering-<abc>.js",
  "server_rendering.js.map": "/packs/js/server_rendering-<abc>.js.map"
}
):
     8:         <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     9:         <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
    10:         <%= javascript_pack_tag 'application' %>
    11:         <%= stylesheet_pack_tag 'application' %>
    12:         <%= favicon_link_tag('koken.ico') %>
    13:     </head>
    14:     <body>
  
app/views/layouts/application.html.erb:11
app/controllers/pages_controller.rb:99:in `show_page'
```