### PR TITLE
disable colorize logging for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,6 +105,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Do not dump ANSI color codes
+  config.colorize_logging = false
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
App Engine does not recognize ANSI color codes