### PR TITLE
remove redundancy; also fix editor disappearing bug

### DIFF
--- a/app/javascript/components/MdEditor/Editor.tsx
+++ b/app/javascript/components/MdEditor/Editor.tsx
@@ -35,12 +35,6 @@ const Editor: FC<{}> = () => {
             tuiEditor?.remove()
         }
     }, [rootEl])
-    useEffect(() => {
-        if (tuiEditor === null) {
-            return
-        }
-        tuiEditor.setMarkdown(markdown)
-    }, [tuiEditor])
     return (
         <Fragment>
             <div ref={rootEl} />


### PR DESCRIPTION
remove redundant `setMarkdown`

Closes #129 
Closes #130 

but still buggy: able to open editor but save fails sometimes
https://github.com/nhn/tui.editor/issues/1456
