### PR TITLE
fix regeneratorRuntime is not defined

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-defaults
+> 0.5% in JP and last 1 version and not ie > 0 and not dead


### PR DESCRIPTION
according to `npx browserslist`, it will drop support for these browsers:

```
and_ff 96
and_qq 10.4
and_uc 12.12
android 98
baidu 7.12
chrome 99
chrome 98
chrome 97
chrome 96
edge 97
firefox 96
firefox 91
ie 11
ios_saf 15.0-15.1
ios_saf 14.5-14.8
ios_saf 14.0-14.4
ios_saf 12.2-12.5
kaios 2.5
op_mini all
op_mob 64
opera 83
opera 82
safari 15.1
safari 14.1
samsung 15.0
```