### PR TITLE
development with docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
-# https://docs.docker.com/compose/rails/
-FROM ruby:2.7
-
-# https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt update -qq && apt install -y nodejs default-mysql-client && rm -rf /var/lib/apt/lists/*
-RUN npm install -g yarn
-RUN gem install bundler -v 2.1.4
-
+FROM node:16 AS prepare-node
 WORKDIR /app
-
-COPY ./Gemfile /app/Gemfile
-COPY ./Gemfile.lock /app/Gemfile.lock
-RUN bundle install --frozen
-
-COPY ./package.json /app/package.json
-COPY ./yarn.lock /app/yarn.lock
+COPY ./package.json ./yarn.lock ./
 RUN yarn install --pure-lockfile
 
+# https://docs.docker.com/compose/rails/
+FROM ruby:2.7
+RUN apt-get update -qq \
+    && apt-get install -y \
+    ca-certificates \
+    default-mysql-client \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+RUN gem install bundler -v 2.1.4
+RUN npm install -g yarn webpack-cli
+WORKDIR /app
+
+COPY ./Gemfile ./Gemfile.lock /app/
+
+RUN bundle install --frozen
+COPY app/javascript/ /app/javascript
+COPY --from=prepare-node /app/node_modules /app/node_modules
+RUN rails javascript:build
 COPY . /app
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
     npm \
     && rm -rf /var/lib/apt/lists/*
 RUN gem install bundler -v 2.1.4
-RUN npm install -g yarn webpack-cli
+RUN npm install -g yarn
 WORKDIR /app
 
 COPY ./Gemfile ./Gemfile.lock /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
-FROM node:16 AS prepare-node
-WORKDIR /app
-COPY ./package.json ./yarn.lock ./
-RUN yarn install --pure-lockfile
-
 # https://docs.docker.com/compose/rails/
-FROM ruby:2.7
+FROM ruby:2.7.3 AS base
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq \
     && apt-get install -y \
     ca-certificates \
     default-mysql-client \
     nodejs \
-    npm \
     && rm -rf /var/lib/apt/lists/*
 RUN gem install bundler -v 2.1.4
 RUN npm install -g yarn
 WORKDIR /app
-
 COPY ./Gemfile ./Gemfile.lock /app/
-
 RUN bundle install --frozen
-COPY app/javascript/ /app/javascript
-COPY --from=prepare-node /app/node_modules /app/node_modules
+
+COPY package.json yarn.lock /app/
+RUN yarn install --pure-lockfile
+COPY app/javascript/ /app/javascript/
 RUN rails javascript:build
+
 COPY . /app
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ Docker and docker compose are recommended to setup your development environment
 
 1. Start services
    - `docker compose up`
-1. Intialize database
-   - `docker compose exec rails rails db:create`
-   - `docker compose exec rails rails db:migrate`
-1. build JavaScript and CSS
-   - `docker compose exec rails rails javascript:build`
 1. visit local development server localhost:3000
 
 ## License

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -x
+set -o pipefail
+rails db:create
+rails db:migrate RAILS_ENV=${RAILS_ENV:=development}

--- a/compose.yml
+++ b/compose.yml
@@ -29,10 +29,10 @@ services:
     build: .
     volumes:
       - mysqlsockdir:/var/run/mysqld
-      # - webpack:/app/assets/build
       - ./app:/app/app:ro
       - ./bin:/app/bin:ro
       - ./config:/app/config:ro
+      - ./public:/app/public:ro
     ports:
       - "3000:3000"
     network_mode: bridge

--- a/compose.yml
+++ b/compose.yml
@@ -5,21 +5,42 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
     volumes:
       - mysqlsockdir:/var/run/mysqld
+      - mysqlvol:/var/lib/mysql
     configs:
       - source: init_sql
         target: /docker-entrypoint-initdb.d/init-mysql-docker-compose.sql
       - source: mysql_cnf
         target: /etc/mysql/conf.d/docker-mysql.cnf
     network_mode: none
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      interval: 1s
+      timeout: 2s
+      retries: 10
+  rails-init-db:
+    build: .
+    volumes:
+      - mysqlsockdir:/var/run/mysqld
+    depends_on:
+      mysql:
+        condition: service_healthy
+    command: ["/app/bin/init"]
   rails:
     build: .
     volumes:
       - mysqlsockdir:/var/run/mysqld
+      # - webpack:/app/assets/build
+      - ./app:/app/app:ro
+      - ./bin:/app/bin:ro
+      - ./config:/app/config:ro
     ports:
       - "3000:3000"
     network_mode: bridge
     depends_on:
-      - mysql
+      rails-init-db:
+        condition: service_completed_successfully
+    command: rails s -p 3000 -b 0.0.0.0
+
 configs:
   init_sql:
     file: init-mysql-docker-compose.sql
@@ -27,3 +48,4 @@ configs:
     file: docker-mysql.cnf
 volumes:
   mysqlsockdir:
+  mysqlvol:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,9 +1744,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001312:
-  version "1.0.30001313"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz#a380b079db91621e1b7120895874e2fd62ed2e2f"
-  integrity sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==
+  version "1.0.30001450"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz"
+  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
once run `docker compose up` command, developers can develop Kokenwiki in Docker.

## changes
- run `db:create` and `db:migrate` in init containers
- run `javascript:build` in Dockerfile
  - so needs to rebuild container image when fixing javascript or CSS sources.
 

close #235 